### PR TITLE
Fix payload length issue

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -89,7 +89,7 @@ int msgarrvd(void *context, char *topicName, int topicLen, MQTTClient_message *m
     qDebug() << "Message arrived (topic is " << topicName << ")";
     qDebug() << "Message payload length is " << message->payloadlen;
     QString payload;
-    payload.sprintf("%s",(char *)message->payload);
+    payload.sprintf("%s", (char *) message->payload).truncate(message->payloadlen);
     emit handle->messageSignal(payload);
     MQTTClient_freeMessage(&message);
     MQTTClient_free(topicName);


### PR DESCRIPTION
Fix a bug occuring where the payload emited in `mainwindow` is copied with more characters than its real length, causing the message to be corrupted.
The fix is done by truncating the payload at the length given as an attribute of the `message` pointer.